### PR TITLE
Implement basic chat room with history

### DIFF
--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -1,0 +1,46 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-size: cover;
+  background-position: center;
+  transition: background-image 0.5s;
+}
+
+body.morning {
+  background: linear-gradient(#fff8dc, #ffeaa7);
+}
+
+body.afternoon {
+  background: linear-gradient(#c2e9fb, #a1c4fd);
+}
+
+body.night {
+  background: linear-gradient(#0d1b2a, #000);
+  color: #eee;
+}
+
+#chat {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+}
+
+#msgs {
+  list-style: none;
+  padding: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+
+#msgs li {
+  margin-bottom: 5px;
+}
+
+#typing {
+  font-style: italic;
+  color: #555;
+}

--- a/public/js/api/chat-client.js
+++ b/public/js/api/chat-client.js
@@ -1,32 +1,74 @@
 const socket = io();
 const roomId = 'global';
-const userInput = document.getElementById('inpUser');
-const msgInput  = document.getElementById('inpMsg');
-const msgsList  = document.getElementById('msgs');
-const typingEl  = document.getElementById('typing');
+let username = '';
+const msgInput = document.getElementById('inpMsg');
+const msgsList = document.getElementById('msgs');
+const typingEl = document.getElementById('typing');
+const joinBtn = document.getElementById('joinBtn');
+const joinSection = document.getElementById('joinSection');
 
-socket.emit('joinRoom', roomId);
-
-document.getElementById('btnSend').onclick = () => {
-  const user = userInput.value.trim();
-  const text = msgInput.value.trim();
-  if (!user || !text) return;
-  socket.emit('chatMessage', { roomId, user, text });
-  msgInput.value = '';
-};
-
-socket.on('newMessage', msg => {
+function addMessage(msg) {
   const li = document.createElement('li');
   li.textContent = `[${new Date(msg.timestamp).toLocaleTimeString()}] ${msg.user}: ${msg.text}`;
   msgsList.appendChild(li);
-});
+}
 
-msgInput.addEventListener('input', () => {
-  const user = userInput.value.trim();
-  socket.emit('typing', { roomId, user });
-});
+async function loadUser() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = '/login';
+    return null;
+  }
+  const res = await fetch('/api/profile', { headers: { 'Authorization': `Bearer ${token}` } });
+  if (!res.ok) {
+    localStorage.removeItem('token');
+    window.location.href = '/login';
+    return null;
+  }
+  const user = await res.json();
+  return { token, username: user.username };
+}
 
-socket.on('userTyping', user => {
-  typingEl.textContent = `${user} đang gõ...`;
-  setTimeout(() => typingEl.textContent = '', 1000);
-});
+function setBackgroundByTime() {
+  const hour = new Date().getHours();
+  if (hour < 12) document.body.classList.add('morning');
+  else if (hour < 18) document.body.classList.add('afternoon');
+  else document.body.classList.add('night');
+}
+
+async function init() {
+  setBackgroundByTime();
+  const info = await loadUser();
+  if (!info) return;
+  username = info.username;
+  const token = info.token;
+
+  joinBtn.onclick = async () => {
+    socket.emit('joinRoom', roomId);
+    const res = await fetch(`/api/chat/history/${roomId}`, { headers: { 'Authorization': `Bearer ${token}` } });
+    if (res.ok) {
+      const history = await res.json();
+      history.forEach(addMessage);
+    }
+    joinSection.style.display = 'none';
+  };
+
+  document.getElementById('btnSend').onclick = () => {
+    const text = msgInput.value.trim();
+    if (!text) return;
+    socket.emit('chatMessage', { roomId, user: username, text });
+    msgInput.value = '';
+  };
+
+  msgInput.addEventListener('input', () => {
+    socket.emit('typing', { roomId, user: username });
+  });
+
+  socket.on('newMessage', addMessage);
+  socket.on('userTyping', (user) => {
+    typingEl.textContent = `${user} đang gõ...`;
+    setTimeout(() => (typingEl.textContent = ''), 1000);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/routes/chatRoute.js
+++ b/routes/chatRoute.js
@@ -1,7 +1,16 @@
 const express = require('express');
-const path = require('path');
 const router = express.Router();
+const Message = require('../model/Message');
+const auth = require('../middleware/authMiddlewave');
 
-
+// get chat history for a room
+router.get('/history/:roomId', auth, async (req, res) => {
+  try {
+    const msgs = await Message.find({ roomId: req.params.roomId }).sort('timestamp');
+    res.json(msgs);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -2,14 +2,21 @@ require('dotenv').config(); // Nạp biến môi trường
 
 const express = require('express');
 const path = require('path');
- const connectDB = require('./config/db')
+const http = require('http');
+const { Server } = require('socket.io');
+const connectDB = require('./config/db');
 const apiRouter = require('./routes/authoRoute');
-const speciesRoute = require('./routes/SpeciesRoute'); 
+const speciesRoute = require('./routes/SpeciesRoute');
+const chatRoute = require('./routes/chatRoute');
+const chatSocket = require('./sockets/chat');
 
 
 const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
 const PORT = process.env.PORT || 3000;
-connectDB()
+connectDB();
+chatSocket(io);
 
 
 // Middleware cơ bản
@@ -20,7 +27,8 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 // Routes API
 app.use('/api', apiRouter);
-app.use('/api/species', speciesRoute); 
+app.use('/api/species', speciesRoute);
+app.use('/api/chat', chatRoute);
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 
@@ -42,6 +50,6 @@ app.use((err, req, res, next) => {
 });
 
 // Start server
-app.listen(PORT, () => {
+server.listen(PORT, () => {
   console.log(`Server đang chạy tại http://localhost:${PORT}`);
 });

--- a/sockets/chat.js
+++ b/sockets/chat.js
@@ -1,14 +1,17 @@
 const Message = require('../model/Message');
 
 module.exports = (io) => {
-  io.on('connection', socket => {
-    socket.on('joinRoom', roomId => socket.join(roomId));
+  io.on('connection', (socket) => {
+    // join a specific chat room
+    socket.on('joinRoom', (roomId) => socket.join(roomId));
 
+    // handle incoming chat message
     socket.on('chatMessage', async ({ roomId, user, text }) => {
       const msg = await Message.create({ roomId, user, text });
       io.to(roomId).emit('newMessage', msg);
     });
 
+    // typing indicator
     socket.on('typing', ({ roomId, user }) => {
       socket.to(roomId).emit('userTyping', user);
     });

--- a/views/chat.html
+++ b/views/chat.html
@@ -8,8 +8,10 @@
 </head>
 <body>
   <div id="chat">
+    <div id="joinSection">
+      <button id="joinBtn">Tham gia trò chuyện</button>
+    </div>
     <ul id="msgs"></ul>
-    <input id="inpUser" placeholder="Tên bạn" />
     <input id="inpMsg" placeholder="Gõ tin nhắn..." />
     <button id="btnSend">Gửi</button>
     <p id="typing"></p>


### PR DESCRIPTION
## Summary
- enable socket.io server integration
- provide chat routes for history API
- implement chat socket handlers
- add dynamic backgrounds and join button in chat view
- improve chat client JS to load profile, fetch history and handle join
- add chat specific styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6858e2dcf0cc8322894d054a1408a452