### PR TITLE
Implement marine species detail view

### DIFF
--- a/public/css/species.css
+++ b/public/css/species.css
@@ -68,6 +68,7 @@ body {
 /* 5. Tinh chỉnh lại thẻ thông tin sinh vật (.species-card)
 -----------------------------------------------------------------------------*/
 .species-card {
+    display: block;
     background-color: rgba(0, 51, 102, 0.6); /* Giữ màu nền đẹp này */
     border-radius: 15px;
     padding: 20px;

--- a/public/js/species/speciesDetailUI.js
+++ b/public/js/species/speciesDetailUI.js
@@ -1,0 +1,21 @@
+const container = document.getElementById('species-detail');
+
+function render(species) {
+  if (!container) return;
+  container.innerHTML = `
+    <h2>${species.name}</h2>
+    <img src="${species.image || '/images/default.jpg'}" alt="${species.name}" style="max-width:100%;border-radius:10px;">
+    <p><strong>Mô tả:</strong> ${species.description || 'Không có mô tả'}</p>
+    <p><strong>Phân bố:</strong> ${species.distribution || 'Không rõ'}</p>
+    <p><strong>Tình trạng:</strong> ${species.conservationStatus || 'Không rõ'}</p>
+  `;
+}
+
+const id = window.location.pathname.split('/').pop();
+fetch(`/api/species/readOne/${id}`)
+  .then(res => res.json())
+  .then(render)
+  .catch(err => {
+    console.error('Lỗi khi tải chi tiết:', err);
+    if (container) container.innerHTML = '<p>Không tìm thấy thông tin.</p>';
+  });

--- a/public/js/species/speciesUI.js
+++ b/public/js/species/speciesUI.js
@@ -6,8 +6,11 @@ if (speciesContainer) {
     .then(res => res.json())
     .then(data => {
       data.forEach(item => {
-        const card = document.createElement('div');
+        const card = document.createElement('a');
         card.className = 'species-card';
+        card.href = `/species/${item._id}`;
+        card.style.textDecoration = 'none';
+        card.style.color = 'inherit';
         card.innerHTML = `
           <img src="${item.image || '/images/default.jpg'}" alt="${item.name}">
           <h3>${item.name}</h3>

--- a/server.js
+++ b/server.js
@@ -37,7 +37,12 @@ app.get('/login', (req, res) => res.sendFile(path.join(__dirname, 'views', 'logi
 app.get('/register', (req, res) => res.sendFile(path.join(__dirname, 'views', 'register.html')));
 app.get('/uploadFile', (req, res) => res.sendFile(path.join(__dirname, 'views', 'upload_file.html')));
 app.get('/profile', (req, res) => res.sendFile(path.join(__dirname, 'views', 'profile.html')));
-app.get('/species', (req, res) => {res.sendFile(path.join(__dirname, 'views', 'species.html'));});
+app.get('/species/:id', (req, res) => {
+  res.sendFile(path.join(__dirname, 'views', 'species_detail.html'));
+});
+app.get('/species', (req, res) => {
+  res.sendFile(path.join(__dirname, 'views', 'species.html'));
+});
 app.get('/add-species', (req, res) => {res.sendFile(path.join(__dirname, 'views', 'add_species.html'));});
 app.get('/rooms', authMiddleware, (req, res) => {
   res.sendFile(path.join(__dirname, 'views', 'rooms.html'));

--- a/views/species_detail.html
+++ b/views/species_detail.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <title>Chi Tiết Sinh Vật Biển</title>
+  <link rel="stylesheet" href="/css/species.css" />
+  <link rel="stylesheet" href="/css/nav.css">
+</head>
+<body>
+<div id="nav-placeholder"></div>
+
+<main class="content-section">
+  <div id="species-detail" class="species-section"></div>
+</main>
+
+<script type="module" src="/js/species/speciesDetailUI.js"></script>
+<script>
+  fetch('/fragments/nav.html')
+    .then(res => res.text())
+    .then(html => { document.getElementById('nav-placeholder').innerHTML = html; })
+    .catch(err => console.error('Không tải được navigation:', err));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new route for marine species detail page
- display marine species as links and create detail page
- fetch and render individual species info via JS
- ensure species card anchors display as blocks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6858eb8fa8b483228d1bab4e862f40ed