### PR TITLE
Implement species pagination

### DIFF
--- a/controllers/speciesController.js
+++ b/controllers/speciesController.js
@@ -11,10 +11,29 @@ exports.create = async (req , res) =>{
         }
 };
 
-exports.readAll = async (req, res) =>{
-    const list = await MarineSpecies.find();
-    res.json(list);
-}
+exports.readAll = async (req, res) => {
+    try {
+        const page = parseInt(req.query.page) || 1;
+        const limit = parseInt(req.query.limit) || 12;
+
+        const [total, species] = await Promise.all([
+            MarineSpecies.countDocuments(),
+            MarineSpecies.find()
+                .skip((page - 1) * limit)
+                .limit(limit)
+        ]);
+
+        const totalPages = Math.ceil(total / limit);
+
+        res.json({
+            species,
+            page,
+            totalPages
+        });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+};
 
 exports.readOne = async (req, res)=>{
     const species = await MarineSpecies.findById(req.params.id);

--- a/public/css/species.css
+++ b/public/css/species.css
@@ -169,6 +169,28 @@ html {
   animation: fadeInUp 1.5s 0.5s ease-out backwards;
 }
 
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+}
+
+.pagination button {
+  margin: 0 4px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background-color: var(--primary-color);
+  color: #fff;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 
 
 

--- a/public/js/species/speciesUI.js
+++ b/public/js/species/speciesUI.js
@@ -1,28 +1,69 @@
 // public/js/speciesUI.js
 
 const speciesContainer = document.getElementById('species-container');
-if (speciesContainer) {
-  fetch('/api/species/readAll')
+const paginationContainer = document.getElementById('pagination');
+const limit = 12;
+
+function createCard(item) {
+  const card = document.createElement('a');
+  card.className = 'species-card';
+  card.href = `/species/${item._id}`;
+  card.style.textDecoration = 'none';
+  card.style.color = 'inherit';
+  card.innerHTML = `
+    <img src="${item.image || '/images/default.jpg'}" alt="${item.name}">
+    <h3>${item.name}</h3>
+    <p><strong>Mô tả:</strong> ${item.description || 'Không có mô tả'}</p>
+    <p><strong>Phân bố:</strong> ${item.distribution || 'Không rõ'}</p>
+    <p><strong>Tình trạng:</strong> ${item.conservationStatus || 'Không rõ'}</p>
+  `;
+  return card;
+}
+
+function renderPagination(totalPages, page) {
+  if (!paginationContainer) return;
+  paginationContainer.innerHTML = '';
+
+  if (page > 1) {
+    const prev = document.createElement('button');
+    prev.textContent = 'Previous';
+    prev.onclick = () => loadSpecies(page - 1);
+    paginationContainer.appendChild(prev);
+  }
+
+  for (let p = 1; p <= totalPages; p++) {
+    const btn = document.createElement('button');
+    btn.textContent = p;
+    if (p === page) btn.disabled = true;
+    btn.onclick = () => loadSpecies(p);
+    paginationContainer.appendChild(btn);
+  }
+
+  if (page < totalPages) {
+    const next = document.createElement('button');
+    next.textContent = 'Next';
+    next.onclick = () => loadSpecies(page + 1);
+    paginationContainer.appendChild(next);
+  }
+}
+
+function loadSpecies(page = 1) {
+  if (!speciesContainer) return;
+  fetch(`/api/species/readAll?page=${page}&limit=${limit}`)
     .then(res => res.json())
     .then(data => {
-      data.forEach(item => {
-        const card = document.createElement('a');
-        card.className = 'species-card';
-        card.href = `/species/${item._id}`;
-        card.style.textDecoration = 'none';
-        card.style.color = 'inherit';
-        card.innerHTML = `
-          <img src="${item.image || '/images/default.jpg'}" alt="${item.name}">
-          <h3>${item.name}</h3>
-          <p><strong>Mô tả:</strong> ${item.description || 'Không có mô tả'}</p>
-          <p><strong>Phân bố:</strong> ${item.distribution || 'Không rõ'}</p>
-          <p><strong>Tình trạng:</strong> ${item.conservationStatus || 'Không rõ'}</p>
-        `;
-        speciesContainer.appendChild(card);
+      speciesContainer.innerHTML = '';
+      data.species.forEach(item => {
+        speciesContainer.appendChild(createCard(item));
       });
+      renderPagination(data.totalPages, data.page);
     })
     .catch(err => {
       speciesContainer.innerHTML = '<p>Lỗi khi tải dữ liệu.</p>';
       console.error('[ERROR] Khi gọi API /api/species:', err);
     });
+}
+
+if (speciesContainer && paginationContainer) {
+  loadSpecies();
 }

--- a/views/species.html
+++ b/views/species.html
@@ -23,6 +23,7 @@
 
   <main class="content-section">
     <div id="species-container" class="species-grid"></div>
+    <div id="pagination" class="pagination"></div>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- add pagination logic to species controller
- update species listing page with a pagination container
- implement front-end pagination controls
- style pagination buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6858f5028430832287b55f0f77f604e5